### PR TITLE
Allow inspector to show when .har has no _intiator

### DIFF
--- a/media/script.js
+++ b/media/script.js
@@ -298,7 +298,7 @@ function selectReq(index) {
     });
 
     $(".stack").html("");
-    if (selectedReq.obj._initiator.type == "script") {
+    if (selectedReq.obj._initiator?.type == "script") {
         for (var i = 0; i < selectedReq.obj._initiator.stack.callFrames.length; i++) {
             var frame = selectedReq.obj._initiator.stack.callFrames[i];
             const re = new RegExp('(?:.+\/)([^\/?]+)', 'gm');


### PR DESCRIPTION
This should fix issue #6! (Unless there are other things that could be missing)

It turns out the reason why the Inspector panel stayed hidden was because the line responsible for unhiding it was the last line of the `selectReq()` function--and that function would die for me because it expected an `_initiator` from the HAR, which mine did not have, turns out